### PR TITLE
Single comment on @params

### DIFF
--- a/R/fnmate.R
+++ b/R/fnmate.R
@@ -166,7 +166,7 @@ build_external_roxygen <- function(fn_arg_names) {
                   "#' @title")
 
   params <-
-    purrr::map_chr(fn_arg_names, ~glue::glue("##' @param {.x}")) %>%
+    purrr::map_chr(fn_arg_names, ~glue::glue("#' @param {.x}")) %>%
     paste0(collapse="\n")
 
   tail <-


### PR DESCRIPTION
The fix of single comment does not work for `@params`.