### PR TITLE
Error handling for missing git repo

### DIFF
--- a/R/git_utils.R
+++ b/R/git_utils.R
@@ -1,5 +1,11 @@
 get_git_user_name <- function() {
-  with(gert::git_config(),
-    value[name == "user.name"]
+  tryCatch(
+    with(gert::git_config(),
+      value[name == "user.name"]
+    ),
+    error = function(cond){
+      message("No Git repo found. Roxygen @author will be left blank.")
+      ""
+    }
   )
 }


### PR DESCRIPTION
The "Create function definition file" action will not proceed in R projects that lack a git repository. The `get_git_user_name()` function throws an "libgit2::git_repository_open_ext : could not find repository" error when there is no repo. This error causes the `glue()` call when populating the Roxygen "author" comment to fail.

I added error handling so that the `get_git_user_name()` function returns an empty string in anticipation of the "libgit2::git_repository_open_ext : could not find repository" error.