### PR TITLE
update to add messaging when multiple functions are found to jump to

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: fnmate
 Title: Create function definitions from function expressions
-Version: 0.0.7
+Version: 0.0.8
 Authors@R: c(person(given = "Miles",
                     family = "McBain",
                     email = "miles.mcbain@gmail.com",
@@ -30,7 +30,7 @@ Suggests:
     rmarkdown,
     testthat (>= 2.1.0)
 VignetteBuilder: knitr
-RoxygenNote: 7.1.1
+RoxygenNote: 7.3.2
 Imports: 
     magrittr,
     purrr,

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: fnmate
 Title: Create function definitions from function expressions
-Version: 0.0.6
+Version: 0.0.7
 Authors@R: c(person(given = "Miles",
                     family = "McBain",
                     email = "miles.mcbain@gmail.com",
@@ -15,6 +15,10 @@ Authors@R: c(person(given = "Miles",
              person(given = "Shir", 
                     family = "Dekel", 
                     email = "shirdekel@yahoo.com.au", 
+                    role = "ctb"),
+             person(given = "Dan", 
+                    family = "Wilson", 
+                    email = "dan+r@birdmail.pro", 
                     role = "ctb"))
 Description: Convert any funcntion expression under the cursor to a definition contained in a file.
 Depends: R (>= 3.5.0)
@@ -36,4 +40,5 @@ Imports:
     clipr,
     utils,
     rlang,
-    gert
+    gert,
+    cli

--- a/R/fnmate.R
+++ b/R/fnmate.R
@@ -115,12 +115,16 @@ write_fn_file <- function(fn_name, fn_defn, fn_folder = getOption("fnmate_folder
   if (file.exists(target_file) &&
       (.fnmate_env$previous_call %||% "") != fn_name) {
     .fnmate_env$previous_call = fn_name
-    message(target_file, " already exists. Call fnmate again on this function to overwrite file.")
+    message(cli::format_message(c(
+      " " = "",
+      "!" = "{target_file}, already exists. Call fnmate again on this function to overwrite file.")))
     return(invisible(target_file))
   }
 
   readr::write_file(x = fn_defn, file = target_file)
-  message("fnmate Wrote ", target_file)
+  message(cli::format_message(c(
+    " " = "",
+    "v" = "fnmate Wrote {col_green(target_file)}")))
   .fnmate_env$previous_call <- NULL
 
   invisible(target_file)
@@ -166,8 +170,8 @@ build_external_roxygen <- function(fn_arg_names) {
                   "#' @title")
 
   params <-
-    purrr::map_chr(fn_arg_names, ~glue::glue("#' @param {.x}")) %>%
-    paste0(collapse="\n")
+    purrr::map_chr(fn_arg_names, ~ glue::glue("#' @param {.x}")) |>
+    paste0(collapse = "\n")
 
   tail <-
     glue::glue(

--- a/R/jump.R
+++ b/R/jump.R
@@ -30,11 +30,21 @@ ripgrep <- function(fn_name) {
   result <- system2("rg", args = c(other_args, search_regex), stdout = TRUE)
 
   if (length(result) < 1) {
+    message(cli::format_message(c(
+      " " = "",
+      "x" = "No function called {.fn {fn_name}} was found."
+    )))
     return(list())
   }
 
   if (length(result) == 1) {
     result_components <- strsplit(result, ":")[[1]]
+
+    message(cli::format_message(c(
+      " " = "",
+      "v" = "Found {.fn {fn_name}} in {.pkg {result_components[[1]]}}",
+      "v" = "Opening {cli::col_green(result_components[[1]])}"
+    )))
 
     return(list(
       file = result_components[[1]],
@@ -55,7 +65,7 @@ ripgrep <- function(fn_name) {
 
   warning(cli::format_warning(c(
     " " = "",
-    "!" =  "There were {length(result)} files with the function {.code {fn_name}} identified to return",
+    "!" =  "There were {length(result)} files with the function {.fn {fn_name}} identified to return",
     "!" = "The files identified are {.pkg {all_files}}",
     "v" = "Opening {cli::col_green(selected_components[[1]])}"
   )))
@@ -76,11 +86,21 @@ git_grep <- function(fn_name) {
   result <- system2("git", args = other_args, stdout = TRUE)
 
   if (length(result) < 1) {
+    message(cli::format_message(c(
+      " " = "",
+      "x" = "No function called {.fn {fn_name}} was found."
+    )))
     return(list())
   }
 
   if (length(result) == 1) {
     result_components <- strsplit(result, ":")[[1]]
+
+    message(cli::format_message(c(
+      " " = "",
+      "v" = "Found {.fn {fn_name}} in {.pkg {result_components[[1]]}}",
+      "v" = "Opening {cli::col_green(result_components[[1]])}"
+    )))
 
     return(list(
       file = result_components[[1]],
@@ -88,7 +108,12 @@ git_grep <- function(fn_name) {
       col = 1
     ))
   }
-
+  # prioritise the first function in the R folder.
+  if (length(grep("^R/", result, value = TRUE)[[1]]) > 0) {
+    selected_result <- grep("^R/", result, value = TRUE)[[1]]
+  } else {
+    selected_result <- result[[1]]
+  }
   all_files <- sapply(strsplit(result, ":"), "[[", 1)
   selected_components <- strsplit(selected_result, ":")[[1]]
 

--- a/R/jump.R
+++ b/R/jump.R
@@ -1,75 +1,118 @@
 jump_fn_definiton <- function(fn_name) {
-    fn_match <- get_search_fn()(fn_name)
+  fn_match <- get_search_fn()(fn_name)
 
-    if (length(fn_match) == 0) {
-        return(NULL)
-    }
+  if (length(fn_match) == 0) {
+    return(NULL)
+  }
 
-    rstudioapi::navigateToFile(
-        fn_match$file,
-        fn_match$row,
-        fn_match$col
-    )
+  rstudioapi::navigateToFile(
+    fn_match$file,
+    fn_match$row,
+    fn_match$col
+  )
 }
 
 get_search_fn <- function() {
-    search_tool <- getOption("fnmate_searcher") %||% "rg"
+  search_tool <- getOption("fnmate_searcher") %||% "rg"
 
-    switch(search_tool,
-        "rg" = ripgrep,
-        "git_grep" = git_grep,
-        function(fn_name) stop("unsupported definition search tool:", search_tool)
-    )
+  switch(search_tool,
+    "rg" = ripgrep,
+    "git_grep" = git_grep,
+    function(fn_name) stop("unsupported definition search tool:", search_tool)
+  )
 }
 
 ripgrep <- function(fn_name) {
-    search_regex <- fnmate_quote_regex(
-        glue::glue("\\b{fn_name}\\s*(?:<-|=)\\s*")
-    )
-    other_args <- c("-m1", "--vimgrep")
-    result <- system2("rg", args = c(other_args, search_regex), stdout = TRUE)
+  search_regex <- fnmate_quote_regex(
+    glue::glue("\\b{fn_name}\\s*(?:<-|=)\\s*")
+  )
+  other_args <- c("-m1", "--vimgrep")
+  result <- system2("rg", args = c(other_args, search_regex), stdout = TRUE)
 
-    if (length(result) < 1) {
-        return(list())
-    }
+  if (length(result) < 1) {
+    return(list())
+  }
 
+  if (length(result) == 1) {
     result_components <- strsplit(result, ":")[[1]]
 
-    list(
-        file = result_components[[1]],
-        row = result_components[[2]],
-        col = result_components[[3]]
-    )
+    return(list(
+      file = result_components[[1]],
+      row = result_components[[2]],
+      col = result_components[[3]]
+    ))
+  }
+
+  # prioritise the first function in the R folder.
+  if (length(grep("^R/", result, value = TRUE)[[1]]) > 0) {
+    selected_result <- grep("^R/", result, value = TRUE)[[1]]
+  } else {
+    selected_result <- result[[1]]
+  }
+
+  all_files <- sapply(strsplit(result, ":"), "[[", 1)
+  selected_components <- strsplit(selected_result, ":")[[1]]
+
+  warning(cli::format_warning(c(
+    " " = "",
+    "!" =  "There were {length(result)} files with the function {.code {fn_name}} identified to return",
+    "!" = "The files identified are {.pkg {all_files}}",
+    "v" = "Opening {cli::col_green(selected_components[[1]])}"
+  )))
+
+  list(
+    file = selected_components[[1]],
+    row = selected_components[[2]],
+    col = selected_components[[3]]
+  )
 }
 
 git_grep <- function(fn_name) {
-    search_regex <- fnmate_quote_regex(
-        glue::glue("\\b{fn_name}\\s*(<-|=)\\s*")
-    )
-    search_pathspec <- fnmate_quote_regex("*.R")
-    other_args <- c("grep", "-nE", "--untracked", search_regex, "--", search_pathspec)
-    result <- system2("git", args = other_args, stdout = TRUE)
+  search_regex <- fnmate_quote_regex(
+    glue::glue("\\b{fn_name}\\s*(<-|=)\\s*")
+  )
+  search_pathspec <- fnmate_quote_regex("*.R")
+  other_args <- c("grep", "-nE", "--untracked", search_regex, "--", search_pathspec)
+  result <- system2("git", args = other_args, stdout = TRUE)
 
-    if (length(result) < 1) {
-        return(list())
-    }
+  if (length(result) < 1) {
+    return(list())
+  }
 
+  if (length(result) == 1) {
     result_components <- strsplit(result, ":")[[1]]
 
-    list(
-        file = result_components[[1]],
-        row = result_components[[2]],
-        col = 1
-    )
+    return(list(
+      file = result_components[[1]],
+      row = result_components[[2]],
+      col = 1
+    ))
+  }
+
+  all_files <- sapply(strsplit(result, ":"), "[[", 1)
+  selected_components <- strsplit(selected_result, ":")[[1]]
+
+  warning(cli::format_warning(c(
+    " " = "",
+    "!" =  "There were {length(result)} files with the function {.code {fn_name}} identified to return",
+    "!" = "The files identified are {.pkg {all_files}}",
+    "v" = "Opening {cli::col_green(selected_components[[1]])}"
+  )))
+
+  list(
+    file = selected_components[[1]],
+    row = selected_components[[2]],
+    col = 1
+  )
 }
 
-# Powershell seems not to like quoting the regex, while  
+# Powershell seems not to like quoting the regex, while
 # As seen in issue #13 MacOS  seems to need it.
 # Linux seems not to care.
 fnmate_quote_regex <- function(regex) {
-    if (getOption("fnmate_quote_jump_regex") %||% FALSE) {
-       glue::glue("'{regex}'") 
-    } else {
-       regex 
-    }
+  if (getOption("fnmate_quote_jump_regex") %||% FALSE) {
+    glue::glue("'{regex}'")
+  } else {
+    regex
+  }
 }

--- a/R/rstudio-addin.R
+++ b/R/rstudio-addin.R
@@ -7,7 +7,7 @@ window_around_cursor <- function(context) {
   start_line <- max(cursor_line - window_size, 1)
   end_line <- min(cursor_line + window_size, length(context$contents))
   text_window <-
-    context$contents[seq(start_line, end_line)] %>%
+    context$contents[seq(start_line, end_line)] |>
     paste0(collapse = "\n")
 
   cursor_line <- cursor_line - start_line + 1
@@ -25,7 +25,10 @@ window_around_cursor <- function(context) {
 #' @export
 rs_fnmate <- function(context = rstudioapi::getActiveDocumentContext()) {
   if (identical(context$id, "#console")) {
-    message("fnmate does not work on console text.")
+    message(cli::format_message(c(
+      " " = "",
+      "i" = "fnmate does not work on console text."
+    )))
     return(invisible(NULL))
   }
 
@@ -43,7 +46,10 @@ rs_fnmate <- function(context = rstudioapi::getActiveDocumentContext()) {
 #' @export
 rs_fnmate_below <- function(context = rstudioapi::getActiveDocumentContext()) {
   if (identical(context$id, "#console")) {
-    message("fnmate does not work on console text.")
+    message(cli::format_message(c(
+      " " = "",
+      "i" = "fnmate does not work on console text."
+    )))
     return(invisible(NULL))
   }
 
@@ -71,7 +77,10 @@ rs_fnmate_below <- function(context = rstudioapi::getActiveDocumentContext()) {
 ##' @export
 rs_fnmate_clip <- function(context = rstudioapi::getActiveDocumentContext()) {
   if (identical(context$id, "#console")) {
-    message("fnmate does not work on console text.")
+    message(cli::format_message(c(
+      " " = "",
+      "i" = "fnmate does not work on console text."
+    )))
     return(invisible(NULL))
   }
 
@@ -82,10 +91,9 @@ rs_fnmate_clip <- function(context = rstudioapi::getActiveDocumentContext()) {
     external = TRUE
   )
 
-  message(
-    "fnmate wrote the definition for `",
-    fnmate_output$fn_name,
-    "()` to the clipboard."
+  message(cli::format_message(c(
+    " " = "",
+    "v" = "fnmate wrote the definition for {.fn fnmate_output$fn_name} to the clipboard."))
   )
 
   clipr::write_clip(fnmate_output$fn_defn, object_type = "character")


### PR DESCRIPTION
In a {targets} pipeline I've had the case where the same function may exist in more than one location. When using the `jump_fn_definition` function it isn't clear which file is being opened. This pull request aims to prioritise files found in the `./R` folder over other locations first, and provides messaging that identifies the files that were found and which file is opened in the editor.